### PR TITLE
PlayerService: setup video surface in all cases

### DIFF
--- a/src/aal/aalmediaplayerservice.cpp
+++ b/src/aal/aalmediaplayerservice.cpp
@@ -413,8 +413,7 @@ void AalMediaPlayerService::setMedia(const QUrl &url)
         }
     }
 
-    if (isVideoSource())
-        m_videoOutput->setupSurface();
+    m_videoOutput->setupSurface();
 }
 
 void AalMediaPlayerService::play()
@@ -426,7 +425,7 @@ void AalMediaPlayerService::play()
         return;
     }
 
-    if (isVideoSource() && m_videoOutput != NULL)
+    if (m_videoOutput != NULL)
     {
         m_videoOutput->autoPlay(true);
 
@@ -436,14 +435,12 @@ void AalMediaPlayerService::play()
 
     // If we previously played and hit the end-of-stream, stop will be called which
     // tears down the video sink. We need a new video sink in order to render video again
-    if (isVideoSource()
-            && !m_videoOutputReady && m_videoOutput->textureId() > 0)
+    if (!m_videoOutputReady && m_videoOutput->textureId() > 0)
     {
         createVideoSink(m_videoOutput->textureId());
     }
 
-    if ((m_videoOutputReady && isVideoSource())
-            || isAudioSource())
+    if (m_videoOutputReady || isAudioSource())
     {
         try {
             m_mediaPlayerControl->setMediaStatus(QMediaPlayer::LoadedMedia);


### PR DESCRIPTION
When a remote media is set, we won't know if it's a video file until we start playing it.

This apparently does not cause disruption in the music player.