### PR TITLE
Pass request headers on to the underlying implementation

### DIFF
--- a/src/aal/aalmediaplayercontrol.cpp
+++ b/src/aal/aalmediaplayercontrol.cpp
@@ -196,7 +196,13 @@ void AalMediaPlayerControl::setMedia(const QMediaContent& media, QIODevice* stre
     Q_UNUSED(stream);
     qDebug() << __PRETTY_FUNCTION__ << endl;
 
-    qDebug() << "setMedia() media: " << AalUtility::unescape(media);
+    const QUrl mediaUrl =
+            AalUtility::unescape(media);
+    const lomiri::MediaHub::Player::Headers headers =
+            AalUtility::extractHeaders(media.canonicalRequest());
+
+    qDebug() << "setMedia() media: " << mediaUrl;
+    qDebug() << "setMedia() headers empty: " << headers.empty();
 
     if (m_mediaContent == media) {
         qDebug() << "Same media as current";
@@ -211,7 +217,7 @@ void AalMediaPlayerControl::setMedia(const QMediaContent& media, QIODevice* stre
         setMediaStatus(QMediaPlayer::LoadingMedia);
 
     // If there is no media this cleans up the play list
-    m_service->setMedia(AalUtility::unescape(media));
+    m_service->setMedia(mediaUrl, headers);
 
     // This is important to do for QMediaPlaylist instances that
     // are set to loop. Without this, such a playlist will only

--- a/src/aal/aalmediaplayerservice.cpp
+++ b/src/aal/aalmediaplayerservice.cpp
@@ -247,7 +247,8 @@ void AalMediaPlayerService::setMediaPlaylist(const QMediaPlaylist &playlist)
     m_mediaPlaylist = &playlist;
 }
 
-void AalMediaPlayerService::setMedia(const QUrl &url)
+void AalMediaPlayerService::setMedia(const QUrl &url,
+                                     const lomiri::MediaHub::Player::Headers &headers)
 {
     if (m_hubPlayerSession == nullptr)
     {
@@ -271,7 +272,7 @@ void AalMediaPlayerService::setMedia(const QUrl &url)
     if (m_mediaPlaylistProvider == nullptr || m_mediaPlaylistProvider->mediaCount() == 0)
     {
         // errors are delivered via Player::errorOccurred()
-        m_hubPlayerSession->openUri(url);
+        m_hubPlayerSession->openUri(url, headers);
     }
 
     m_videoOutput->setupSurface();

--- a/src/aal/aalmediaplayerservice.h
+++ b/src/aal/aalmediaplayerservice.h
@@ -71,7 +71,7 @@ public:
     QAudio::Role audioRole() const;
     void setAudioRole(QAudio::Role audioRole);
 
-    void setMedia(const QUrl &url);
+    void setMedia(const QUrl &url, const lomiri::MediaHub::Player::Headers &headers);
     void setMediaPlaylist(const QMediaPlaylist& playlist);
     void play();
     void pause();

--- a/src/aal/aalutility.cpp
+++ b/src/aal/aalutility.cpp
@@ -44,3 +44,13 @@ std::string AalUtility::unescape_str(const QMediaContent &media)
 {
     return unescape(media).toString().toStdString();
 }
+
+lomiri::MediaHub::Player::Headers AalUtility::extractHeaders(const QNetworkRequest& request)
+{
+    lomiri::MediaHub::Player::Headers extractedHeaders;
+    for (const QByteArray& headerKey : request.rawHeaderList()) {
+        const QByteArray headerVal = request.rawHeader(headerKey);
+        extractedHeaders.insert(QString::fromUtf8(headerKey), QString::fromUtf8(headerVal));
+    }
+    return extractedHeaders;
+}

--- a/src/aal/aalutility.h
+++ b/src/aal/aalutility.h
@@ -22,10 +22,13 @@
 
 #include <string>
 
+#include <MediaHub/Player>
+
 struct AalUtility
 {
     static QUrl unescape(const QMediaContent &media);
     static std::string unescape_str(const QMediaContent &media);
+    static lomiri::MediaHub::Player::Headers extractHeaders(const QNetworkRequest& request);
 
     AalUtility() = delete;
     AalUtility(const AalUtility&) = delete;


### PR DESCRIPTION
Make it possible to pass HTTP headers, like for authorization purposes, on to media-hub.

~~Requires: https://github.com/ubports/media-hub/pull/19~~

Prerequisite is included as part of libmedia-hub-qt rewrite.